### PR TITLE
[Fix] view_rebuffer_duration, view_time_to_first_frame to ms from v4

### DIFF
--- a/uizacoresdk/src/main/java/uizacoresdk/util/TmpParamData.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/util/TmpParamData.java
@@ -497,5 +497,6 @@ public class TmpParamData {
 
     public void addViewWatchTime(long addViewWatchTime) {
         this.viewWatchTime += addViewWatchTime;
+        this.viewTimeToFirstFrame = this.viewWatchTime;
     }
 }

--- a/uizacoresdk/src/main/java/uizacoresdk/view/floatview/FUZVideo.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/floatview/FUZVideo.java
@@ -656,25 +656,29 @@ public class FUZVideo extends RelativeLayout {
         switch (playbackState) {
             case Player.STATE_BUFFERING:
                 showProgress();
-                if (playWhenReady) {
-                    TmpParamData.getInstance().setViewRebufferDuration(System.currentTimeMillis() - timestampRebufferStart);
-                    timestampRebufferStart = 0;
-                    addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFEREND);
-                } else {
-                    timestampRebufferStart = System.currentTimeMillis();
-                    addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFERSTART);
-                    TmpParamData.getInstance().addViewRebufferCount();
+                timestampRebufferStart = System.currentTimeMillis();
+                addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFERSTART);
+                TmpParamData.getInstance().addViewRebufferCount();
+                if (!playWhenReady) {
                     addTrackingMuiza(Constants.MUIZA_EVENT_WAITING);
                 }
                 break;
             case Player.STATE_ENDED:
+                timestampRebufferStart = 0;
                 setDefaultValueForFlagIsTracked();
                 addTrackingMuiza(Constants.MUIZA_EVENT_VIEWENDED);
                 break;
             case Player.STATE_IDLE:
+                timestampRebufferStart = 0;
                 showProgress();
                 break;
             case Player.STATE_READY:
+                if (timestampRebufferStart != 0) {
+                    TmpParamData.getInstance().setViewRebufferDuration(System.currentTimeMillis() - timestampRebufferStart);
+                    addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFEREND);
+                }
+                timestampRebufferStart = 0;
+
                 if (!isOnStateReadyFirst) {
                     onStateReadyFirst();
                     isOnStateReadyFirst = true;

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZPlayerManager.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZPlayerManager.java
@@ -558,29 +558,33 @@ public final class UZPlayerManager implements AdsMediaSource.MediaSourceFactory,
                 case Player.STATE_BUFFERING:
                     showProgress();
                     if (uzVideo != null) {
-                        if (playWhenReady) {
-                            TmpParamData.getInstance().setViewRebufferDuration(System.currentTimeMillis() - timestampRebufferStart);
-                            timestampRebufferStart = 0;
-                            uzVideo.addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFEREND);
-                        } else {
-                            timestampRebufferStart = System.currentTimeMillis();
-                            uzVideo.addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFERSTART);
-                            TmpParamData.getInstance().addViewRebufferCount();
+                        timestampRebufferStart = System.currentTimeMillis();
+                        uzVideo.addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFERSTART);
+                        TmpParamData.getInstance().addViewRebufferCount();
+                        if (!playWhenReady) {
                             uzVideo.addTrackingMuiza(Constants.MUIZA_EVENT_WAITING);
                         }
                     }
                     break;
                 case Player.STATE_ENDED:
+                    timestampRebufferStart = 0;
                     if (uzVideo != null) {
                         uzVideo.onPlayerEnded();
                     }
                     hideProgress();
                     break;
                 case Player.STATE_IDLE:
+                    timestampRebufferStart = 0;
                     showProgress();
                     break;
                 case Player.STATE_READY:
                     hideProgress();
+                    if (timestampRebufferStart != 0) {
+                        TmpParamData.getInstance().setViewRebufferDuration(System.currentTimeMillis() - timestampRebufferStart);
+                        uzVideo.addTrackingMuiza(Constants.MUIZA_EVENT_REBUFFEREND);
+                    }
+                    timestampRebufferStart = 0;
+
                     if (playWhenReady) {
                         // media actually playing
                         if (uzVideo != null) {


### PR DESCRIPTION
Description
Fix view_rebuffer_duration, view_time_to_first_frame to ms not timestamp from v4

Ticket URL
https://uizaio.atlassian.net/browse/EBC-327
https://uizaio.atlassian.net/browse/EBC-328