### PR TITLE
[Task] Calculate HLS latency when Player with no Ads

### DIFF
--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
@@ -68,8 +68,4 @@ abstract class IUZPlayerManager implements PreviewLoader {
     abstract ExoPlaybackException getExoPlaybackException();
 
     abstract void setResumeIfConnectionError();
-
-    protected long calculateLiveStreamLatencyInMs(long startTimeUs) {
-        return System.currentTimeMillis() - startTimeUs / 1000;
-    }
 }

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZPlayerNoAdsManager.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZPlayerNoAdsManager.java
@@ -3,6 +3,7 @@ package uizacoresdk.view.rl.video;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
+import android.os.SystemClock;
 import android.text.TextUtils;
 import android.widget.ImageView;
 import com.bumptech.glide.request.target.Target;
@@ -62,10 +63,12 @@ import uizacoresdk.glide.GlideThumbnailTransformationPB;
 import uizacoresdk.interfaces.UZBufferCallback;
 import uizacoresdk.listerner.ProgressCallback;
 import uizacoresdk.util.TmpParamData;
+import uizacoresdk.util.UZUtil;
 import uizacoresdk.view.rl.timebar.UZTimebar;
 import vn.uiza.core.common.Constants;
 import vn.uiza.core.exception.UZExceptionUtil;
 import vn.uiza.core.utilities.LConnectivityUtil;
+import vn.uiza.core.utilities.LDateUtils;
 import vn.uiza.core.utilities.LLog;
 import vn.uiza.core.utilities.LUIUtil;
 import vn.uiza.restapi.uiza.model.v2.listallentity.Subtitle;
@@ -74,6 +77,9 @@ import vn.uiza.views.autosize.UZImageButton;
 
 public final class UZPlayerNoAdsManager extends IUZPlayerManager {
     private final String TAG = "TAG" + getClass().getSimpleName();
+    private static final String EXT_X_PROGRAM_DATE_TIME = "#EXT-X-PROGRAM-DATE-TIME:";
+    private static final String EXTINF = "#EXTINF:";
+    private static final long INVALID_PROGRAM_DATE_TIME = 0;
     private Context context;
     private UZVideo uzVideo;
     private final DataSource.Factory manifestDataSourceFactory;
@@ -460,16 +466,71 @@ public final class UZPlayerNoAdsManager extends IUZPlayerManager {
                 if (uzVideo.eventListener != null)
                     uzVideo.eventListener.onTimelineChanged(timeline, manifest, reason);
                 if (manifest instanceof HlsManifest) {
-                    HlsMediaPlaylist hlsMediaPlaylist = ((HlsManifest) manifest).mediaPlaylist;
-                    if (hlsMediaPlaylist.hasProgramDateTime) {
-                        uzVideo.updateLiveStreamLatency(calculateLiveStreamLatencyInMs(hlsMediaPlaylist.startTimeUs));
-                    } else {
+                    HlsMediaPlaylist playlist = ((HlsManifest) manifest).mediaPlaylist;
+                    // From the current playing frame to end time of chunk
+                    long timeToEndChunk = player.getDuration() - player.getCurrentPosition();
+                    long extProgramDateTime = getProgramDateTimeValue(playlist, timeToEndChunk);
+
+                    if (extProgramDateTime == INVALID_PROGRAM_DATE_TIME) {
                         uzVideo.hideTextLiveStreamLatency();
+                        return;
                     }
+
+                    long elapsedTime = SystemClock.elapsedRealtime() - UZUtil.getLastElapsedTime(context);
+                    long currentTime = UZUtil.getLastServerTime(context) + elapsedTime;
+
+                    long latency = currentTime - extProgramDateTime;
+                    uzVideo.updateLiveStreamLatency(latency);
                 } else {
                     uzVideo.hideTextLiveStreamLatency();
                 }
             }
+        }
+
+        private long getProgramDateTimeValue(HlsMediaPlaylist playlist, long timeToEndChunk) {
+            if (playlist.tags == null) {
+                return INVALID_PROGRAM_DATE_TIME;
+            }
+            final String emptyStr = "";
+            final int tagSize = playlist.tags.size();
+
+            long totalTime = 0;
+            int playingIndex = tagSize;
+
+            // Find the playing frame index
+            while (playingIndex >= 0) {
+                String tag = playlist.tags.get(playingIndex - 1);
+                if (tag.contains(EXTINF)) {
+                    totalTime += Double.parseDouble(tag.replace(",", emptyStr).replace(EXTINF, emptyStr)) * 1000;
+                    if (totalTime >= timeToEndChunk) {
+                        break;
+                    }
+                }
+                playingIndex--;
+            }
+            if (playingIndex >= tagSize) {
+                // That means the livestream latency is larger than 1 segment (duration).
+                // we should skip to calc latency in this case
+                return INVALID_PROGRAM_DATE_TIME;
+            }
+
+            // Find the playing frame EXT_X_PROGRAM_DATE_TIME
+            String playingDateTime = emptyStr;
+            for (int i = playingIndex; i < tagSize; i++) {
+                String tag = playlist.tags.get(i);
+                if (tag.contains(EXT_X_PROGRAM_DATE_TIME)) {
+                    playingDateTime = tag.replace(EXT_X_PROGRAM_DATE_TIME, emptyStr);
+                    break;
+                }
+            }
+
+            if (TextUtils.isEmpty(playingDateTime)) {
+                // That means something wrong with the format, check with server
+                // we should skip to calc latency in this case
+                return INVALID_PROGRAM_DATE_TIME;
+            }
+            // int list of frame, we get the EXT_X_PROGRAM_DATE_TIME of current playing frame
+            return LDateUtils.convertUTCMs(playingDateTime);
         }
 
         //This is called when the available or selected tracks change


### PR DESCRIPTION
**Description**
- Calculate HLS Latency on developer mode
- NOTE:
  - In case user seek the `seekbar` time to previous which over the current playing `segment` duration, skip to calculate the latency.
  - Currently the latency value is:
  ` long latency = Frame_Displayed_Time - EXT_X_PROGRAM_DATE_TIME` 

(both value are based on `UTC` time).

**Impacted Area**
- None

**Ticket URL**
- https://uizaio.atlassian.net/browse/EBC-386

Related to #133 