### PR TITLE
[Fix] Prevent camera crashes caused by camera resolution is not supported

### DIFF
--- a/uizalivestream/src/main/java/uizalivestream/view/RtmpCameraHelper.java
+++ b/uizalivestream/src/main/java/uizalivestream/view/RtmpCameraHelper.java
@@ -245,9 +245,13 @@ final class RtmpCameraHelper {
         }
     }
 
-    void startPreview(CameraHelper.Facing facing, int width, int height) {
-        if (!isCameraValid()) return;
-        rtmpCamera1.startPreview(facing, width, height);
+    boolean startPreview(CameraHelper.Facing facing, int width, int height) {
+        if (!isCameraValid()) return false;
+        if (checkCanOpen(facing, width, height)) {
+            rtmpCamera1.startPreview(facing, width, height);
+            return true;
+        }
+        return false;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
@@ -375,5 +379,20 @@ final class RtmpCameraHelper {
             }
         }
         return bestResolutionFrontList;
+    }
+
+    private boolean checkCanOpen(CameraHelper.Facing facing, int width, int height) {
+        List<Camera.Size> previews;
+        if (facing == CameraHelper.Facing.BACK) {
+            previews = rtmpCamera1.getResolutionsBack();
+        } else {
+            previews = rtmpCamera1.getResolutionsFront();
+        }
+        for (Camera.Size size : previews) {
+            if (size.width == width && size.height == height) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/uizalivestream/src/main/java/uizalivestream/view/UZLivestream.java
+++ b/uizalivestream/src/main/java/uizalivestream/view/UZLivestream.java
@@ -380,8 +380,12 @@ public class UZLivestream extends RelativeLayout
             uzLivestreamCallback.surfaceChanged(new StartPreview() {
                 @Override
                 public void onSizeStartPreview(int width, int height) {
-                    cameraHelper.startPreview(CameraHelper.Facing.FRONT, width, height);
-                    updateUISurfaceView(width, height);
+                    boolean canStart = cameraHelper.startPreview(CameraHelper.Facing.FRONT, width, height);
+                    if (canStart) {
+                        updateUISurfaceView(width, height);
+                    } else {
+                        uzLivestreamCallback.onError(getString(R.string.camera_not_running_properly));
+                    }
                 }
             });
         }


### PR DESCRIPTION
**Description**
- In some of devices (especially emulator), camera resolution is not supported like real designed phone, so crash maybe happened when showing camera => check the supported resolution before showing camera.
 