### PR TITLE
[Fix] Fix some issues why playing with android 4.x

### DIFF
--- a/sample/src/main/java/testlibuiza/sample/v3/linkplay/PlayerActivity.java
+++ b/sample/src/main/java/testlibuiza/sample/v3/linkplay/PlayerActivity.java
@@ -76,7 +76,7 @@ public class PlayerActivity extends AppCompatActivity implements UZCallback, UZI
         uZCustomLinkPlay1.setLivestream(true);
 
         final UZCustomLinkPlay uZCustomLinkPlay2 = new UZCustomLinkPlay();
-        uZCustomLinkPlay2.setLinkPlay("https://stag-asia-southeast1-live.uizadev.io/998a1a17138644428ce028d2de20c5a0-live/593fd077-313c-4d11-a5ec-fbd66dc43763/playlist_dvr.m3u8");
+        uZCustomLinkPlay2.setLinkPlay("https://asia-southeast1-live.uizacdn.net/f785bc511967473fbe6048ee5fb7ea59-live/e3a3d39f-6bd7-4a82-9e90-70bfa9e1f92d/playlist_dvr.m3u8");
         uZCustomLinkPlay2.setLivestream(true);
 
         final UZCustomLinkPlay uZCustomLinkPlay3 = new UZCustomLinkPlay();

--- a/sample/src/main/res/layout/activity_fb_list_video.xml
+++ b/sample/src/main/res/layout/activity_fb_list_video.xml
@@ -18,7 +18,7 @@
         <ImageView
             android:layout_width="@dimen/w_25"
             android:layout_height="@dimen/w_25"
-            android:src="@drawable/ic_switch_camera_white_24dp" />
+            app:srcCompat="@drawable/ic_switch_camera_white_24dp" />
 
         <ImageView
             android:layout_width="@dimen/w_25"
@@ -41,7 +41,7 @@
             android:layout_width="@dimen/w_25"
             android:layout_height="@dimen/w_25"
             android:layout_marginLeft="@dimen/margin_10"
-            android:src="@drawable/ic_settings_white_24dp"
+            app:srcCompat="@drawable/ic_settings_white_24dp"
             android:tint="@color/White" />
     </LinearLayout>
 

--- a/sample/src/main/res/layout/framgia_controller_skin_custom_detail.xml
+++ b/sample/src/main/res/layout/framgia_controller_skin_custom_detail.xml
@@ -32,7 +32,7 @@
             android:background="@color/transparent"
             android:contentDescription="@string/app_name"
             android:scaleType="centerInside"
-            android:src="@drawable/animation"
+            app:srcCompat="@drawable/animation"
             android:tint="@color/Red"
             app:useDefaultIB="false" />
 

--- a/sample/src/main/res/layout/uiza_controller_skin_custom_detail.xml
+++ b/sample/src/main/res/layout/uiza_controller_skin_custom_detail.xml
@@ -32,7 +32,7 @@
             android:background="@color/transparent"
             android:contentDescription="@string/app_name"
             android:scaleType="centerInside"
-            android:src="@drawable/animation"
+            app:srcCompat="@drawable/animation"
             android:tint="@color/Red"
             app:useDefaultIB="false" />
 

--- a/uizabase/build.gradle
+++ b/uizabase/build.gradle
@@ -32,6 +32,11 @@ android {
         //release & debug is in project animators
         //matchingFallbacks = ['release', 'debug']
     }
+    compileOptions {
+        // from 2.9.0 need turn on Java 8 support https://exoplayer.dev/hello-world.html#turn-on-java-8-support
+        // https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#290
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/uizacoresdk/build.gradle
+++ b/uizacoresdk/build.gradle
@@ -34,6 +34,11 @@ android {
         //release & debug is in project animators
         //matchingFallbacks = ['release', 'debug']
     }
+    compileOptions {
+        // from 2.9.0 need turn on Java 8 support https://exoplayer.dev/hello-world.html#turn-on-java-8-support
+        // https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#290
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
@@ -2,6 +2,7 @@ package uizacoresdk.view.rl.video;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
 import android.text.TextUtils;
@@ -125,7 +126,7 @@ abstract class IUZPlayerManager implements PreviewLoader {
         this.bufferPosition = 0;
         this.bufferPercentage = 0;
         this.uzVideo = uzVideo;
-        this.linkPlay = linkPlay;
+        this.linkPlay = processLinkPlay(linkPlay);
         this.subtitleList = subtitleList;
         this.isFirstStateReady = false;
 
@@ -515,6 +516,17 @@ abstract class IUZPlayerManager implements PreviewLoader {
             }
         }
         return mediaSourceWithSubtitle;
+    }
+
+    /**
+     * @return the link play of vod or live, note that we force use http if android device version is below 22
+     * <code>(Build.VERSION_CODES.LOLLIPOP_MR1)</code>
+     */
+    private String processLinkPlay(String linkPlay) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1 && linkPlay.startsWith(Constants.PREFIXS)) {
+            return linkPlay.replace(Constants.PREFIXS, Constants.PREFIX);
+        }
+        return linkPlay;
     }
 
     private void onFirstStateReady() {

--- a/uizalivestream/build.gradle
+++ b/uizalivestream/build.gradle
@@ -32,6 +32,11 @@ android {
         //release & debug is in project animators
         //matchingFallbacks = ['release', 'debug']
     }
+    compileOptions {
+        // from 2.9.0 need turn on Java 8 support https://exoplayer.dev/hello-world.html#turn-on-java-8-support
+        // https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#290
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
**Description**
- Update Java 1.8 compatibility for ExoPlayer 2.9.x
- Force use http for android version below 22(LOLLIPOP_MR1)

**Detail info**
  - from 2.9.0 need turn on Java 8 support https://exoplayer.dev/hello-world.html#turn-on-java-8-support
  - https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#290