### PR TITLE
[Improvement] Try to Resume Livestream when come back from background

### DIFF
--- a/sample/src/main/java/testlibuiza/sample/v3/linkplay/PlayerActivity.java
+++ b/sample/src/main/java/testlibuiza/sample/v3/linkplay/PlayerActivity.java
@@ -72,7 +72,7 @@ public class PlayerActivity extends AppCompatActivity implements UZCallback, UZI
         uZCustomLinkPlay0.setLivestream(false);
 
         final UZCustomLinkPlay uZCustomLinkPlay1 = new UZCustomLinkPlay();
-        uZCustomLinkPlay1.setLinkPlay("https://vod.straas.net/companyId/100592/1496984341rl74rdlvsh/playlist.m3u8");
+        uZCustomLinkPlay1.setLinkPlay("https://vn-southeast-1-live.uizacdn.net/9521cff34e86473095644ba71cbd0e7f-live/a16a4689-0a56-4256-af7c-b9006354c0f1/playlist_dvr.m3u8");
         uZCustomLinkPlay1.setLivestream(true);
 
         final UZCustomLinkPlay uZCustomLinkPlay2 = new UZCustomLinkPlay();

--- a/samplelivestream/src/main/java/test/loitp/samplelivestream/App.java
+++ b/samplelivestream/src/main/java/test/loitp/samplelivestream/App.java
@@ -7,11 +7,11 @@ import vn.uiza.core.common.Constants;
 
 public class App extends MultiDexApplication {
     //TODO input information of your workspace
-    public static final String DF_DOMAIN_API = "ap-southeast-1-api.uiza.co/";
-    public static final String DF_TOKEN = "uap-b99d6b58428043ffbbc2091054ef3442-dae7e075";
-    public static final String DF_APP_ID = "b99d6b58428043ffbbc2091054ef3442";
-    public static String entityIdDefaultLIVE_TRANSCODE = "b21e1ecb-dab9-4435-b492-6681f2b1ff5d";
-    public static String entityIdDefaultLIVE_NO_TRANSCODE = "aab8b32e-438a-4f86-8478-f82139de8902";
+    public static final String DF_DOMAIN_API = "stag-ap-southeast-1-api.uizadev.io";
+    public static final String DF_TOKEN = "uap-998a1a17138644428ce028d2de20c5a0-53d927eb";
+    public static final String DF_APP_ID = "998a1a17138644428ce028d2de20c5a0";
+    public static String entityIdDefaultLIVE_TRANSCODE = "7cb5b495-bf41-41ac-be67-5307cc1cb1a9";
+    public static String entityIdDefaultLIVE_NO_TRANSCODE = "34dfc318-9f6a-4540-a382-4574d67ecefc";
 
     @Override
     public void onCreate() {

--- a/samplelivestream/src/main/java/test/loitp/samplelivestream/LiveLandscapeActivity.java
+++ b/samplelivestream/src/main/java/test/loitp/samplelivestream/LiveLandscapeActivity.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import com.pedro.encoder.input.gl.render.filters.AndroidViewFilterRender;
 import com.pedro.encoder.input.gl.render.filters.BasicDeformationFilterRender;
 import com.pedro.encoder.input.gl.render.filters.BeautyFilterRender;
@@ -101,6 +102,7 @@ public class LiveLandscapeActivity extends AppCompatActivity implements View.OnC
         btSwitchCamera.setOnClickListener(this);
         btFilter.setOnClickListener(this);
         btFlash.setOnClickListener(this);
+        uzLivestream.setBackgroundAllowedDuration(10000);
     }
 
     @Override
@@ -388,6 +390,11 @@ public class LiveLandscapeActivity extends AppCompatActivity implements View.OnC
                 bStartStopStore.setText("Start stream and Store");
             }
         });
+    }
+
+    @Override
+    public void onBackgroundTooLong() {
+        LToast.show(getApplicationContext(), "You go to background for a long time !", Toast.LENGTH_LONG);
     }
 
     @Override

--- a/samplelivestream/src/main/java/test/loitp/samplelivestream/LivePortraitActivity.java
+++ b/samplelivestream/src/main/java/test/loitp/samplelivestream/LivePortraitActivity.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import com.pedro.encoder.input.gl.render.filters.AndroidViewFilterRender;
 import com.pedro.encoder.input.gl.render.filters.BasicDeformationFilterRender;
 import com.pedro.encoder.input.gl.render.filters.BeautyFilterRender;
@@ -102,6 +103,7 @@ public class LivePortraitActivity extends AppCompatActivity implements View.OnCl
         btSwitchCamera.setOnClickListener(this);
         btFilter.setOnClickListener(this);
         btFlash.setOnClickListener(this);
+        uzLivestream.setBackgroundAllowedDuration(10000);
     }
 
     @Override
@@ -375,6 +377,11 @@ public class LivePortraitActivity extends AppCompatActivity implements View.OnCl
             LToast.show(activity, "Cannot use this feature because user does not allow our permissions");
             onBackPressed();
         }
+    }
+
+    @Override
+    public void onBackgroundTooLong() {
+        LToast.show(getApplicationContext(), "You go to background for a long time !", Toast.LENGTH_LONG);
     }
 
     @Override

--- a/uizalivestream/src/main/java/uizalivestream/interfaces/UZLivestreamCallback.java
+++ b/uizalivestream/src/main/java/uizalivestream/interfaces/UZLivestreamCallback.java
@@ -27,4 +27,6 @@ public interface UZLivestreamCallback {
     void surfaceCreated();
 
     void surfaceChanged(UZLivestream.StartPreview startPreview);
+
+    void onBackgroundTooLong();
 }


### PR DESCRIPTION
**Description**
- When `broadcaster` app goes to background incidentally or not, he/she can continue resume the current livestream after a limit duration.

1. Set the background limit duration that you want to allow auto to continue livestream when comback from background. The default duration is 2 minutes.
```
uzLivestream.setBackgroundAllowedDuration(duration);
```
2. If over that time, when resume you will get the callback `onBackgroundTooLong()` and you must call start stream by yourself to livestream again.
