### PR TITLE
[Fix] Revert Rtp library to 1.5.2 for the livestream quality

### DIFF
--- a/uizalivestream/build.gradle
+++ b/uizalivestream/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     api project(':uizabase')
     //https://github.com/pedroSG94/rtmp-rtsp-stream-client-java
-    api 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.6.2'
+    api 'com.github.pedroSG94.rtmp-rtsp-stream-client-java:rtplibrary:1.5.2'
 
     // if you want to modify the version of these dependencies, check this link below
     // https://github.com/powermock/powermock/wiki/Mockito


### PR DESCRIPTION
**Description**
- Because the quality in version `1.6.2` is not good, so downgrade it to `1.5.2` & we will try to find the rootcause later.

**Note**
- Here is [adaptive bitrate](https://github.com/pedroSG94/rtmp-rtsp-stream-client-java/wiki/Adaptative-video-bitrate) docs.
- `(1.5.2  || 1.6.2) && adaptive bitrate` => bad quality.
- `1.5.2 && !adaptive bitrate` => better quality