### PR TITLE
[Fix] Prevent crashing when HLS video can not be parsed

### DIFF
--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/IUZPlayerManager.java
@@ -688,7 +688,7 @@ abstract class IUZPlayerManager implements PreviewLoader {
         }
 
         private long getProgramDateTimeValue(HlsMediaPlaylist playlist, long timeToEndChunk) {
-            if (playlist.tags == null) {
+            if (playlist == null || playlist.tags == null || playlist.tags.isEmpty()) {
                 return INVALID_PROGRAM_DATE_TIME;
             }
             final String emptyStr = "";


### PR DESCRIPTION
**Description**
- Prevent crashing when HLS video can not be parsed