### PR TITLE
[Fix] Change entityName to Stream Name

### DIFF
--- a/uizacoresdk/src/main/java/uizacoresdk/view/floatview/FUZVideo.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/floatview/FUZVideo.java
@@ -564,7 +564,7 @@ public class FUZVideo extends RelativeLayout {
         uizaTrackingCCU.setDt(LDateUtils.getCurrent(LDateUtils.FORMAT_1));
         uizaTrackingCCU.setHo(cdnHost);
         uizaTrackingCCU.setAi(UZData.getInstance().getAppId());
-        uizaTrackingCCU.setSn(UZData.getInstance().getEntityName());
+        uizaTrackingCCU.setSn(UZData.getInstance().getChannelName()); // stream name
         uizaTrackingCCU.setDi(UZOsUtil.getDeviceId(getContext()));
         uizaTrackingCCU.setUa(Constants.USER_AGENT);
         UZAPIMaster.getInstance().subscribe(service.trackCCU(uizaTrackingCCU), new ApiSubscriber<Object>() {

--- a/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
+++ b/uizacoresdk/src/main/java/uizacoresdk/view/rl/video/UZVideo.java
@@ -3334,7 +3334,7 @@ public class UZVideo extends RelativeLayout
         uizaTrackingCCU.setDt(LDateUtils.getCurrent(LDateUtils.FORMAT_1));
         uizaTrackingCCU.setHo(cdnHost);
         uizaTrackingCCU.setAi(UZData.getInstance().getAppId());
-        uizaTrackingCCU.setSn(UZData.getInstance().getEntityName());
+        uizaTrackingCCU.setSn(UZData.getInstance().getChannelName()); // stream name
         uizaTrackingCCU.setDi(UZOsUtil.getDeviceId(getContext()));
         uizaTrackingCCU.setUa(Constants.USER_AGENT);
         UZAPIMaster.getInstance().subscribe(service.trackCCU(uizaTrackingCCU), new ApiSubscriber<Object>() {


### PR DESCRIPTION
**Description**
- Change `entityName` to use `Stream Name` when track CCU for livestream